### PR TITLE
feat: add remix button to Items

### DIFF
--- a/app/items/BuildItemView.tsx
+++ b/app/items/BuildItemView.tsx
@@ -105,9 +105,15 @@ const EXAMPLE_ITEMS: Record<string, Omit<Item, "creator">> = {
 
 interface BuildItemViewProps {
   item?: Item;
+  existingItem?: Item;
+  remixedFromId?: string;
 }
 
-export default function BuildItemView({ item }: BuildItemViewProps) {
+export default function BuildItemView({
+  item,
+  existingItem,
+  remixedFromId,
+}: BuildItemViewProps) {
   const id = useId();
   const router = useRouter();
   const { data: session } = useSession();
@@ -120,20 +126,22 @@ export default function BuildItemView({ item }: BuildItemViewProps) {
     },
   });
 
+  const sourceData = item || existingItem;
+
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      name: item?.name || "",
-      kind: item?.kind || "",
-      description: item?.description || "",
-      moreInfo: item?.moreInfo || "",
-      imageIcon: item?.imageIcon || "",
-      imageBgIcon: item?.imageBgIcon || "",
-      imageColor: item?.imageColor || "",
-      imageBgColor: item?.imageBgColor || "",
-      rarity: item?.rarity || "unspecified",
-      visibility: item?.visibility || "public",
-      sourceId: item?.source?.id || "",
+      name: sourceData?.name || "",
+      kind: sourceData?.kind || "",
+      description: sourceData?.description || "",
+      moreInfo: sourceData?.moreInfo || "",
+      imageIcon: sourceData?.imageIcon || "",
+      imageBgIcon: sourceData?.imageBgIcon || "",
+      imageColor: sourceData?.imageColor || "",
+      imageBgColor: sourceData?.imageBgColor || "",
+      rarity: sourceData?.rarity || "unspecified",
+      visibility: sourceData?.visibility || "public",
+      sourceId: sourceData?.source?.id || "",
     },
   });
 
@@ -191,6 +199,7 @@ export default function BuildItemView({ item }: BuildItemViewProps) {
         visibility: data.visibility,
         sourceId:
           data.sourceId && data.sourceId !== "none" ? data.sourceId : undefined,
+        ...(remixedFromId && { remixedFromId }),
       };
       const result = isEditing
         ? await updateItem(item.id, payload)

--- a/app/items/[itemId]/page.tsx
+++ b/app/items/[itemId]/page.tsx
@@ -4,6 +4,7 @@ import { Card } from "@/app/ui/item/Card";
 import { AddToCollectionDialog } from "@/components/AddToCollectionDialog";
 import { ItemCollections } from "@/components/ItemCollections";
 import { ItemDetailActions } from "@/components/ItemDetailActions";
+import { ItemRemixes } from "@/components/ItemRemixes";
 import { auth } from "@/lib/auth";
 import { itemsService } from "@/lib/services/items";
 import { SITE_NAME } from "@/lib/utils/branding";
@@ -73,11 +74,12 @@ export default async function ItemPage({
   if (itemId !== slugify(item)) {
     return permanentRedirect(getItemUrl(item));
   }
-  //
-  // if item is not public, then user must be creator
-  const isOwner = session?.user?.discordId === item.creator?.discordId || false;
 
   const collections = await itemsService.getItemCollections(uid);
+  const remixes = await itemsService.getItemRemixes(uid);
+
+  // if item is not public, then user must be creator
+  const isOwner = session?.user?.discordId === item.creator?.discordId || false;
 
   if (item.visibility !== "public" && !isOwner) {
     return notFound();
@@ -86,15 +88,18 @@ export default async function ItemPage({
   return (
     <div>
       <div className="flex justify-end items-start gap-2 mb-6">
-        {isOwner && <ItemDetailActions item={item} />}
         {session?.user && (
-          <AddToCollectionDialog type="item" itemId={item.id} />
+          <>
+            <ItemDetailActions item={item} isOwner={isOwner} />
+            <AddToCollectionDialog type="item" itemId={item.id} />
+          </>
         )}
       </div>
       <div className="flex justify-center">
         <div className="flex flex-col items-center gap-12 max-w-sm w-full">
           <Card item={item} creator={item.creator} link={false} />
           <ItemCollections collections={collections} />
+          <ItemRemixes remixes={remixes} />
         </div>
       </div>
     </div>

--- a/app/items/new/page.tsx
+++ b/app/items/new/page.tsx
@@ -1,5 +1,32 @@
 import BuildItemView from "@/app/items/BuildItemView";
+import { itemsService } from "@/lib/services/items";
+import { deslugify } from "@/lib/utils/slug";
 
-export default async function NewItemPage() {
-  return <BuildItemView />;
+export default async function NewItemPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ remix?: string }>;
+}) {
+  const { remix: remixSlug } = await searchParams;
+
+  let sourceItem = null;
+  let remixId: string | undefined;
+  if (remixSlug) {
+    const uuid = deslugify(remixSlug);
+    if (uuid) {
+      remixId = uuid;
+      sourceItem = await itemsService.getItem(uuid);
+      if (!sourceItem) {
+        remixId = undefined;
+        sourceItem = null;
+      }
+    }
+  }
+
+  return (
+    <BuildItemView
+      existingItem={sourceItem || undefined}
+      remixedFromId={remixId}
+    />
+  );
 }

--- a/components/ItemDetailActions.tsx
+++ b/components/ItemDetailActions.tsx
@@ -1,18 +1,20 @@
 "use client";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Shuffle, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import { deleteItem } from "@/app/actions/item";
 import { Button } from "@/components/ui/button";
 import type { Item } from "@/lib/services/items";
+import { slugify } from "@/lib/utils/slug";
 import { getItemEditUrl } from "@/lib/utils/url";
 
 interface ItemDetailActionsProps {
   item: Item;
+  isOwner: boolean;
 }
 
-export function ItemDetailActions({ item }: ItemDetailActionsProps) {
+export function ItemDetailActions({ item, isOwner }: ItemDetailActionsProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -37,20 +39,30 @@ export function ItemDetailActions({ item }: ItemDetailActionsProps) {
 
   return (
     <div className="flex gap-2">
+      {isOwner && (
+        <>
+          <Button variant="outline" size="sm" asChild>
+            <Link href={getItemEditUrl(item)}>
+              <Pencil className="w-4 h-4" />
+              Edit
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleDelete}
+            disabled={isPending}
+          >
+            <Trash2 className="w-4 h-4" />
+            Delete
+          </Button>
+        </>
+      )}
       <Button variant="outline" size="sm" asChild>
-        <Link href={getItemEditUrl(item)}>
-          <Pencil className="w-4 h-4" />
-          Edit
+        <Link href={`/items/new?remix=${slugify(item)}`}>
+          <Shuffle className="w-4 h-4" />
+          Remix
         </Link>
-      </Button>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={handleDelete}
-        disabled={isPending}
-      >
-        <Trash2 className="w-4 h-4" />
-        Delete
       </Button>
     </div>
   );

--- a/components/ItemRemixes.tsx
+++ b/components/ItemRemixes.tsx
@@ -1,0 +1,39 @@
+import { Attribution } from "@/app/ui/Attribution";
+import { Link } from "@/components/app/Link";
+import type { User } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { getItemUrl } from "@/lib/utils/url";
+
+interface Remix {
+  id: string;
+  name: string;
+  creator: User;
+}
+
+interface ItemRemixesProps {
+  remixes: Remix[];
+}
+
+export function ItemRemixes({ remixes }: ItemRemixesProps) {
+  if (remixes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="w-full max-w-lg">
+      <h3 className={cn("font-condensed text-lg pb-1 border-b-2 mb-4")}>
+        Remixes
+      </h3>
+      <div className="space-y-3">
+        {remixes.map((remix) => (
+          <div key={remix.id} className="flex gap-2 justify-between">
+            <Link href={getItemUrl(remix)} className="text-lg font-medium">
+              {remix.name}
+            </Link>
+            <Attribution user={remix.creator} showUsername={false} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/services/items/repository.ts
+++ b/lib/services/items/repository.ts
@@ -232,6 +232,7 @@ export const createItem = async (
     rarity,
     visibility,
     sourceId,
+    remixedFromId,
   } = input;
 
   const user = await prisma.user.findUnique({
@@ -258,6 +259,7 @@ export const createItem = async (
         connect: { id: user.id },
       },
       ...(sourceId && { source: { connect: { id: sourceId } } }),
+      ...(remixedFromId && { remixedFrom: { connect: { id: remixedFromId } } }),
     },
     include: {
       creator: true,
@@ -320,4 +322,25 @@ export const updateItem = async (
   });
 
   return toItem(updatedItem);
+};
+
+export const findItemRemixes = async (itemId: string) => {
+  if (!isValidUUID(itemId)) return [];
+
+  const remixes = await prisma.item.findMany({
+    where: {
+      remixedFromId: itemId,
+      visibility: "public",
+    },
+    include: {
+      creator: true,
+    },
+    orderBy: { name: "asc" },
+  });
+
+  return remixes.map((item) => ({
+    id: item.id,
+    name: item.name,
+    creator: toUser(item.creator),
+  }));
 };

--- a/lib/services/items/service.ts
+++ b/lib/services/items/service.ts
@@ -33,6 +33,10 @@ export class ItemsService {
     return repository.findItemCollections(itemId);
   }
 
+  async getItemRemixes(itemId: string) {
+    return repository.findItemRemixes(itemId);
+  }
+
   async createItem(
     input: CreateItemInput,
     creatorDiscordId: string

--- a/lib/services/items/types.ts
+++ b/lib/services/items/types.ts
@@ -32,6 +32,8 @@ export interface Item extends ItemMini {
   creator: User;
   source?: Source;
   awards?: Award[];
+  remixedFromId?: string | null;
+  remixedFrom?: { id: string; name: string; creator: User } | null;
 }
 
 export type ItemSortBy = "name" | "createdAt";
@@ -59,6 +61,7 @@ export interface CreateItemInput {
   rarity?: ItemRarity;
   visibility: "public" | "private";
   sourceId?: string;
+  remixedFromId?: string;
 }
 
 export interface UpdateItemInput {

--- a/prisma/migrations/20251125195735_add_item_remixed_from/migration.sql
+++ b/prisma/migrations/20251125195735_add_item_remixed_from/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "items" ADD COLUMN     "remixed_from_id" UUID;
+
+-- AddForeignKey
+ALTER TABLE "items" ADD CONSTRAINT "items_remixed_from_id_fkey" FOREIGN KEY ("remixed_from_id") REFERENCES "items"("id") ON DELETE SET NULL ON UPDATE NO ACTION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -201,6 +201,7 @@ model Item {
   visibility      item_visibility    @default(public)
   userId          String             @map("user_id") @db.Uuid
   sourceId        String?            @map("source_id") @db.Uuid
+  remixedFromId   String?            @map("remixed_from_id") @db.Uuid
   createdAt       DateTime           @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt       DateTime           @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
   imageIcon       String?            @map("image_icon")
@@ -208,8 +209,10 @@ model Item {
   imageBgIcon     String?            @map("image_bg_icon")
   imageColor      String?            @map("image_color")
   imageBgColor    String?            @map("image_bg_color")
-  creator         User               @relation(fields: [userId], references: [id], onUpdate: NoAction)
+  creator         User               @relation("ItemCreator", fields: [userId], references: [id], onUpdate: NoAction)
   source          Source?            @relation(fields: [sourceId], references: [id], onUpdate: NoAction)
+  remixedFrom     Item?              @relation("ItemRemix", fields: [remixedFromId], references: [id], onUpdate: NoAction)
+  remixes         Item[]             @relation("ItemRemix")
   itemCollections ItemInCollection[]
   itemAwards      ItemAward[]
 
@@ -341,7 +344,7 @@ model User {
   collections  Collection[]
   companions   Companion[]
   conditions   Condition[]
-  items        Item[]
+  items        Item[]        @relation("ItemCreator")
   monsters     Monster[]     @relation("MonsterCreator")
   sessions     Session[]
   subclasses   Subclass[]


### PR DESCRIPTION
Implements remix functionality for items, mirroring the existing monster
remix feature. Users can now create remixed versions of items, which
tracks the original item and displays all remixes on the item detail page.

Changes:
- Add remixedFromId field to Item model in Prisma schema
- Create migration for Item remixedFromId field
- Update Item types to include remixedFromId and remixedFrom
- Update item repository and service to handle remixedFromId
- Add findItemRemixes and getItemRemixes functions
- Update ItemDetailActions with Remix button (using Shuffle icon)
- Make Edit/Delete buttons only visible to item owner
- Create ItemRemixes component to display remixes
- Update item detail page to show remixes and pass isOwner prop
- Update new item page to handle remix search parameter
- Update BuildItemView to accept existingItem and remixedFromId props