### PR TITLE
Add Claude session hooks for dependency setup

### DIFF
--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Claude session initialization hook
+# Only runs in Claude Code web environment
+
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR" || exit 1
+
+# Install dependencies if node_modules doesn't exist or is outdated
+if [ ! -d "node_modules" ] || [ "pnpm-lock.yaml" -nt "node_modules" ]; then
+  pnpm install --frozen-lockfile 2>&1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-init.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds SessionStart hook that runs pnpm install when Claude Code
starts a web session. This ensures dependencies are always set up
correctly in the remote environment.