### PR TITLE
Include family abilities in JSON API responses

### DIFF
--- a/app/api/monsters/route.test.ts
+++ b/app/api/monsters/route.test.ts
@@ -523,7 +523,13 @@ describe("GET /api/monsters", () => {
           {
             id: "660e8400-e29b-41d4-a716-446655440001",
             name: "Goblinoids",
-            abilities: [],
+            abilities: [
+              {
+                id: "abil-1",
+                name: "Pack Tactics",
+                description: "Gains advantage when allies are nearby",
+              },
+            ],
             creatorId: "user123",
             creator: fakeCreator,
           },
@@ -553,6 +559,11 @@ describe("GET /api/monsters", () => {
     expect(data.included).toHaveLength(1);
     expect(data.included[0].type).toBe("families");
     expect(data.included[0].attributes.name).toBe("Goblinoids");
+    expect(data.included[0].attributes.abilities).toHaveLength(1);
+    expect(data.included[0].attributes.abilities[0]).toEqual({
+      name: "Pack Tactics",
+      description: "Gains advantage when allies are nearby",
+    });
   });
 
   it("should not include families when include is not specified", async () => {

--- a/lib/services/families/converters.test.ts
+++ b/lib/services/families/converters.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { FamilyOverview } from "@/lib/types";
+import { toJsonApiFamily } from "./converters";
+
+describe("toJsonApiFamily", () => {
+  const baseFamily: FamilyOverview = {
+    id: "660e8400-e29b-41d4-a716-446655440001",
+    name: "Goblinoids",
+    description: "A family of goblin-like creatures",
+    abilities: [],
+    creatorId: "user123",
+    creator: {
+      id: "user123",
+      discordId: "discord123",
+      username: "testuser",
+      displayName: "Test User",
+    },
+    monsterCount: 5,
+  };
+
+  it("should include abilities in attributes", () => {
+    const family: FamilyOverview = {
+      ...baseFamily,
+      abilities: [
+        {
+          id: "abil-1",
+          name: "Pack Tactics",
+          description: "Gains advantage when allies are nearby",
+        },
+        {
+          id: "abil-2",
+          name: "Nimble Escape",
+          description: "Can disengage or hide as a bonus action",
+        },
+      ],
+    };
+
+    const result = toJsonApiFamily(family);
+
+    expect(result.attributes.abilities).toEqual([
+      {
+        name: "Pack Tactics",
+        description: "Gains advantage when allies are nearby",
+      },
+      {
+        name: "Nimble Escape",
+        description: "Can disengage or hide as a bonus action",
+      },
+    ]);
+  });
+
+  it("should return empty abilities array when family has no abilities", () => {
+    const result = toJsonApiFamily(baseFamily);
+
+    expect(result.attributes.abilities).toEqual([]);
+  });
+
+  it("should not include ability ids in the output", () => {
+    const family: FamilyOverview = {
+      ...baseFamily,
+      abilities: [
+        {
+          id: "abil-1",
+          name: "Pack Tactics",
+          description: "Gains advantage when allies are nearby",
+        },
+      ],
+    };
+
+    const result = toJsonApiFamily(family);
+
+    expect(result.attributes.abilities[0]).not.toHaveProperty("id");
+  });
+});

--- a/lib/services/families/converters.ts
+++ b/lib/services/families/converters.ts
@@ -8,6 +8,10 @@ export const toJsonApiFamily = (f: FamilyOverview) => {
     attributes: {
       name: f.name,
       description: f.description,
+      abilities: f.abilities.map((a) => ({
+        name: a.name,
+        description: a.description,
+      })),
       monsterCount: f.monsterCount,
     },
     relationships: {


### PR DESCRIPTION
## Summary
This PR adds family abilities to the JSON API serialization for monster families, allowing clients to access ability information when families are included in API responses.

## Key Changes
- **Updated `toJsonApiFamily` converter**: Modified the family-to-JSON-API conversion to include an `abilities` array in the response attributes, mapping each ability to include only `name` and `description` (excluding the internal `id`)
- **Added comprehensive test coverage**: Created new test file `lib/services/families/converters.test.ts` with three test cases covering:
  - Abilities are correctly included in the JSON API output
  - Empty abilities arrays are handled properly
  - Ability IDs are not exposed in the serialized output
- **Updated existing API test**: Enhanced the monsters API test to verify that abilities are properly included when families are fetched via the `include` parameter

## Implementation Details
- Abilities are serialized without their IDs to avoid exposing internal identifiers in the API response
- The converter uses a simple map transformation to extract only the `name` and `description` fields from each ability
- This change maintains backward compatibility while extending the API's data exposure for family-related information

https://claude.ai/code/session_01P8uVDuQM39GTheUKS6roMW