### PR TITLE
Fix circular dependencies in codebase

### DIFF
--- a/lib/db/converters.ts
+++ b/lib/db/converters.ts
@@ -1,11 +1,11 @@
 import { toItemMini } from "@/lib/services/items/converters";
+import { toMonsterMini } from "@/lib/services/monsters/converters";
 import type {
   Ability,
   Action,
   CollectionOverview,
   Companion,
   CompanionMini,
-  FamilyOverview,
   Spell,
   SpellSchool,
   SpellSchoolMini,
@@ -13,43 +13,24 @@ import type {
   SubclassAbility,
   SubclassLevel,
   SubclassMini,
-  User,
 } from "@/lib/types";
-import { toMonsterMini } from "../services/monsters/converters";
+import {
+  type ConverterUserRow,
+  parseJsonField,
+  toFamilyOverview,
+  toUser,
+} from "./shared-converters";
 
-export const parseJsonField = <T>(value: unknown): T[] => {
-  if (!value) return [];
-  if (Array.isArray(value)) return value;
-  if (typeof value === "string") {
-    try {
-      return JSON.parse(value);
-    } catch {
-      return [];
-    }
-  }
-  return [];
-};
+// Re-export shared converters for backwards compatibility
+export {
+  type ConverterUserRow,
+  parseJsonField,
+  toFamilyOverview,
+  toUser,
+} from "./shared-converters";
 
-// Generic type for family with creator
-interface FamilyWithCreator {
-  id: string;
-  name: string;
-  description: string | null;
-  abilities: unknown;
-  visibility: string | null;
-  creatorId: string;
-  creator: UserRow;
-}
-
-// Generic type for user row
-interface UserRow {
-  id: string;
-  discordId: string | null;
-  username: string | null;
-  displayName: string | null;
-  imageUrl: string | null;
-  avatar: string | null;
-}
+// Type alias for backwards compatibility
+type UserRow = ConverterUserRow;
 
 // Generic type for collection with relations
 interface CollectionWithRelations {
@@ -205,28 +186,6 @@ interface SpellWithSchool extends SpellDbRow {
   };
 }
 
-export const toFamilyOverview = (
-  f: FamilyWithCreator | null
-): FamilyOverview | undefined => {
-  if (!f) {
-    return undefined;
-  }
-  return {
-    id: f.id,
-    name: f.name,
-    description: f.description ?? undefined,
-    abilities: parseJsonField<Omit<Ability, "id">>(f.abilities).map(
-      (ability) => ({
-        ...ability,
-        id: crypto.randomUUID(),
-      })
-    ),
-    visibility: f.visibility as FamilyOverview["visibility"],
-    creatorId: f.creatorId,
-    creator: toUser(f.creator),
-  };
-};
-
 export const toCollectionOverview = (
   c: CollectionWithRelations
 ): CollectionOverview => {
@@ -318,18 +277,6 @@ export const toCompanion = (c: CompanionRow): Companion => {
       })) || undefined,
   };
 };
-
-export const toUser = (u: UserRow): User => ({
-  id: u.id,
-  discordId: u.discordId ?? "",
-  username: u.username ?? "",
-  displayName: u.displayName || u.username || "",
-  imageUrl:
-    u.imageUrl ||
-    (u.avatar
-      ? `https://cdn.discordapp.com/avatars/${u.discordId}/${u.avatar}.png`
-      : "https://cdn.discordapp.com/embed/avatars/0.png"),
-});
 
 export const toSubclassMini = (
   s: Pick<

--- a/lib/db/shared-converters.ts
+++ b/lib/db/shared-converters.ts
@@ -1,0 +1,69 @@
+import type { Ability, FamilyOverview, User } from "@/lib/types/base";
+
+// Generic type for user row
+export interface ConverterUserRow {
+  id: string;
+  discordId: string | null;
+  username: string | null;
+  displayName: string | null;
+  imageUrl: string | null;
+  avatar: string | null;
+}
+
+// Generic type for family with creator
+interface FamilyWithCreator {
+  id: string;
+  name: string;
+  description: string | null;
+  abilities: unknown;
+  visibility: string | null;
+  creatorId: string;
+  creator: ConverterUserRow;
+}
+
+export const parseJsonField = <T>(value: unknown): T[] => {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return [];
+    }
+  }
+  return [];
+};
+
+export const toUser = (u: ConverterUserRow): User => ({
+  id: u.id,
+  discordId: u.discordId ?? "",
+  username: u.username ?? "",
+  displayName: u.displayName || u.username || "",
+  imageUrl:
+    u.imageUrl ||
+    (u.avatar
+      ? `https://cdn.discordapp.com/avatars/${u.discordId}/${u.avatar}.png`
+      : "https://cdn.discordapp.com/embed/avatars/0.png"),
+});
+
+export const toFamilyOverview = (
+  f: FamilyWithCreator | null
+): FamilyOverview | undefined => {
+  if (!f) {
+    return undefined;
+  }
+  return {
+    id: f.id,
+    name: f.name,
+    description: f.description ?? undefined,
+    abilities: parseJsonField<Omit<Ability, "id">>(f.abilities).map(
+      (ability) => ({
+        ...ability,
+        id: crypto.randomUUID(),
+      })
+    ),
+    visibility: f.visibility as FamilyOverview["visibility"],
+    creatorId: f.creatorId,
+    creator: toUser(f.creator),
+  };
+};

--- a/lib/services/ancestries/repository.ts
+++ b/lib/services/ancestries/repository.ts
@@ -16,7 +16,6 @@ import type { Source, User } from "@/lib/types";
 import type { CursorData } from "@/lib/utils/cursor";
 import { decodeCursor, encodeCursor } from "@/lib/utils/cursor";
 import { isValidUUID } from "@/lib/utils/validation";
-import type { PaginateAncestriesParams } from "./service";
 import type {
   Ancestry,
   AncestryAbility,
@@ -24,6 +23,7 @@ import type {
   AncestryRarity,
   AncestrySize,
   CreateAncestryInput,
+  PaginateAncestriesParams,
   SearchAncestriesParams,
   UpdateAncestryInput,
 } from "./types";

--- a/lib/services/ancestries/service.ts
+++ b/lib/services/ancestries/service.ts
@@ -1,18 +1,17 @@
 import { z } from "zod";
 import * as repository from "./repository";
-import type {
-  Ancestry,
-  CreateAncestryInput,
-  SearchAncestriesParams,
-  UpdateAncestryInput,
+import {
+  type Ancestry,
+  type CreateAncestryInput,
+  type PaginateAncestriesParams,
+  PaginateAncestriesSortOptions,
+  type PaginatePublicAncestriesResponse,
+  type SearchAncestriesParams,
+  type UpdateAncestryInput,
 } from "./types";
 
-const PaginateAncestriesSortOptions = [
-  "-createdAt",
-  "createdAt",
-  "name",
-  "-name",
-] as const;
+// Re-export pagination types for backwards compatibility
+export type { PaginateAncestriesParams, PaginatePublicAncestriesResponse };
 
 const PaginateAncestriesSchema = z.object({
   search: z.string().optional(),
@@ -22,13 +21,6 @@ const PaginateAncestriesSchema = z.object({
   creatorId: z.string().optional(),
   sourceId: z.string().optional(),
 });
-
-export type PaginateAncestriesParams = z.infer<typeof PaginateAncestriesSchema>;
-
-export type PaginatePublicAncestriesResponse = {
-  data: Ancestry[];
-  nextCursor: string | null;
-};
 
 export class AncestriesService {
   async getAncestry(id: string): Promise<Ancestry | null> {

--- a/lib/services/ancestries/types.ts
+++ b/lib/services/ancestries/types.ts
@@ -1,4 +1,4 @@
-import type { Award, Source, User } from "@/lib/types";
+import type { Award, Source, User } from "@/lib/types/base";
 
 export const SIZES = [
   { value: "tiny", label: "Tiny" },
@@ -41,6 +41,30 @@ export interface Ancestry extends AncestryMini {
 
 export type AncestrySortBy = "name" | "createdAt";
 export type AncestrySortDirection = "asc" | "desc";
+
+export const PaginateAncestriesSortOptions = [
+  "-createdAt",
+  "createdAt",
+  "name",
+  "-name",
+] as const;
+
+export type PaginateAncestriesSortOption =
+  (typeof PaginateAncestriesSortOptions)[number];
+
+export interface PaginateAncestriesParams {
+  search?: string;
+  sort?: PaginateAncestriesSortOption;
+  limit?: number;
+  cursor?: string;
+  creatorId?: string;
+  sourceId?: string;
+}
+
+export interface PaginatePublicAncestriesResponse {
+  data: Ancestry[];
+  nextCursor: string | null;
+}
 
 export interface SearchAncestriesParams {
   searchTerm?: string;

--- a/lib/services/backgrounds/repository.ts
+++ b/lib/services/backgrounds/repository.ts
@@ -16,11 +16,11 @@ import type { Source, User } from "@/lib/types";
 import type { CursorData } from "@/lib/utils/cursor";
 import { decodeCursor, encodeCursor } from "@/lib/utils/cursor";
 import { isValidUUID } from "@/lib/utils/validation";
-import type { PaginateBackgroundsParams } from "./service";
 import type {
   Background,
   BackgroundMini,
   CreateBackgroundInput,
+  PaginateBackgroundsParams,
   SearchBackgroundsParams,
   UpdateBackgroundInput,
 } from "./types";

--- a/lib/services/backgrounds/service.ts
+++ b/lib/services/backgrounds/service.ts
@@ -1,18 +1,17 @@
 import { z } from "zod";
 import * as repository from "./repository";
-import type {
-  Background,
-  CreateBackgroundInput,
-  SearchBackgroundsParams,
-  UpdateBackgroundInput,
+import {
+  type Background,
+  type CreateBackgroundInput,
+  type PaginateBackgroundsParams,
+  PaginateBackgroundsSortOptions,
+  type PaginatePublicBackgroundsResponse,
+  type SearchBackgroundsParams,
+  type UpdateBackgroundInput,
 } from "./types";
 
-const PaginateBackgroundsSortOptions = [
-  "-createdAt",
-  "createdAt",
-  "name",
-  "-name",
-] as const;
+// Re-export pagination types for backwards compatibility
+export type { PaginateBackgroundsParams, PaginatePublicBackgroundsResponse };
 
 const PaginateBackgroundsSchema = z.object({
   search: z.string().optional(),
@@ -22,15 +21,6 @@ const PaginateBackgroundsSchema = z.object({
   creatorId: z.string().optional(),
   sourceId: z.string().optional(),
 });
-
-export type PaginateBackgroundsParams = z.infer<
-  typeof PaginateBackgroundsSchema
->;
-
-export type PaginatePublicBackgroundsResponse = {
-  data: Background[];
-  nextCursor: string | null;
-};
 
 export class BackgroundsService {
   async getBackground(id: string): Promise<Background | null> {

--- a/lib/services/backgrounds/types.ts
+++ b/lib/services/backgrounds/types.ts
@@ -1,4 +1,4 @@
-import type { Award, Source, User } from "@/lib/types";
+import type { Award, Source, User } from "@/lib/types/base";
 
 export interface BackgroundMini {
   id: string;
@@ -17,6 +17,30 @@ export interface Background extends BackgroundMini {
 
 export type BackgroundSortBy = "name" | "createdAt";
 export type BackgroundSortDirection = "asc" | "desc";
+
+export const PaginateBackgroundsSortOptions = [
+  "-createdAt",
+  "createdAt",
+  "name",
+  "-name",
+] as const;
+
+export type PaginateBackgroundsSortOption =
+  (typeof PaginateBackgroundsSortOptions)[number];
+
+export interface PaginateBackgroundsParams {
+  search?: string;
+  sort?: PaginateBackgroundsSortOption;
+  limit?: number;
+  cursor?: string;
+  creatorId?: string;
+  sourceId?: string;
+}
+
+export interface PaginatePublicBackgroundsResponse {
+  data: Background[];
+  nextCursor: string | null;
+}
 
 export interface SearchBackgroundsParams {
   searchTerm?: string;

--- a/lib/services/items/converters.ts
+++ b/lib/services/items/converters.ts
@@ -1,4 +1,4 @@
-import { toUser } from "@/lib/db/converters";
+import { toUser } from "@/lib/db/shared-converters";
 import { uuidToIdentifier } from "@/lib/utils/slug";
 import type { Item, ItemMini, ItemRarity } from "./types";
 

--- a/lib/services/items/types.ts
+++ b/lib/services/items/types.ts
@@ -1,4 +1,4 @@
-import type { Award, Source, User } from "@/lib/types";
+import type { Award, Source, User } from "@/lib/types/base";
 
 export const RARITIES = [
   { value: "unspecified", label: "Unspecified" },

--- a/lib/services/monsters/converters.ts
+++ b/lib/services/monsters/converters.ts
@@ -1,4 +1,4 @@
-import { toFamilyOverview, toUser } from "@/lib/db/converters";
+import { toFamilyOverview, toUser } from "@/lib/db/shared-converters";
 import { getPaperforgeEntry } from "@/lib/paperforge-catalog";
 import type { Ability, Action, FamilyOverview } from "@/lib/types";
 import { uuidToIdentifier } from "@/lib/utils/slug";

--- a/lib/services/monsters/repository.ts
+++ b/lib/services/monsters/repository.ts
@@ -37,12 +37,12 @@ import { decodeCursor, encodeCursor } from "@/lib/utils/cursor";
 import { isValidUUID } from "@/lib/utils/validation";
 import { extractAllConditions, syncMonsterConditions } from "./conditions";
 import { syncMonsterFamilies } from "./families";
-import type { PaginateMonstersParams } from "./service";
 import type {
   CreateMonsterInput,
   Monster,
   MonsterMini,
   MonsterRole,
+  PaginateMonstersParams,
   SearchMonstersParams,
   UpdateMonsterInput,
 } from "./types";

--- a/lib/services/monsters/service.ts
+++ b/lib/services/monsters/service.ts
@@ -7,10 +7,15 @@ import {
   type MonsterMini,
   MonsterRoleOptions,
   MonsterTypeOptions,
+  type PaginateMonstersParams,
   PaginateMonstersSortOptions,
+  type PaginatePublicMonstersResponse,
   type SearchMonstersParams,
   type UpdateMonsterInput,
 } from "./types";
+
+// Re-export pagination types for backwards compatibility
+export type { PaginateMonstersParams, PaginatePublicMonstersResponse };
 
 const PaginateMonstersSchema = z.object({
   search: z.string().optional(),
@@ -23,13 +28,6 @@ const PaginateMonstersSchema = z.object({
   role: z.enum(MonsterRoleOptions).optional(),
   level: z.number().optional(),
 });
-
-export type PaginateMonstersParams = z.infer<typeof PaginateMonstersSchema>;
-
-export type PaginatePublicMonstersResponse = {
-  data: Monster[];
-  nextCursor: string | null;
-};
 
 export class MonstersService {
   async getPublicMonster(id: string): Promise<Monster | null> {

--- a/lib/services/monsters/types.ts
+++ b/lib/services/monsters/types.ts
@@ -5,7 +5,7 @@ import type {
   FamilyOverview,
   Source,
   User,
-} from "@/lib/types";
+} from "@/lib/types/base";
 
 export const SIZES = [
   { value: "tiny", label: "Tiny" },
@@ -166,6 +166,23 @@ export const PaginateMonstersSortOptions = [
 ] as const;
 export type PaginateMonstersSortOption =
   (typeof PaginateMonstersSortOptions)[number];
+
+export interface PaginateMonstersParams {
+  search?: string;
+  sort?: PaginateMonstersSortOption;
+  limit?: number;
+  cursor?: string;
+  type?: MonsterTypeOption;
+  creatorId?: string;
+  sourceId?: string;
+  role?: MonsterRole;
+  level?: number;
+}
+
+export interface PaginatePublicMonstersResponse {
+  data: Monster[];
+  nextCursor: string | null;
+}
 
 export interface CreateMonsterInput {
   name: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,12 +3,34 @@ import type {
   Background,
   BackgroundMini,
 } from "@/lib/services/backgrounds/types";
-import type { Item, ItemMini } from "@/lib/services/items";
+import type { Item, ItemMini } from "@/lib/services/items/types";
 import type {
   Monster,
   MonsterMini,
   MonsterSize,
-} from "@/lib/services/monsters";
+} from "@/lib/services/monsters/types";
+import type {
+  Ability,
+  Action,
+  Award,
+  FamilyOverview,
+  Source,
+  User,
+} from "@/lib/types/base";
+
+// Re-export base types for backwards compatibility
+export {
+  type Ability,
+  type Action,
+  type Award,
+  type Condition,
+  FAMILY_VISIBILITY,
+  type FamilyOverview,
+  type FamilyVisibility,
+  type Source,
+  UNKNOWN_USER,
+  type User,
+} from "@/lib/types/base";
 
 export const CollectionVisibility = {
   PUBLIC: "public",
@@ -53,24 +75,6 @@ export const COLOR_VARIANTS = [200, 400, 600] as const;
 export type TailwindColor = (typeof TAILWIND_COLORS)[number];
 export type ColorVariant = (typeof COLOR_VARIANTS)[number];
 
-export const FAMILY_VISIBILITY = [
-  { value: "public", label: "Public" },
-  { value: "secret", label: "Secret" },
-  { value: "private", label: "Private" },
-] as const;
-export type FamilyVisibility = (typeof FAMILY_VISIBILITY)[number]["value"];
-
-export interface FamilyOverview {
-  id: string;
-  name: string;
-  description?: string;
-  abilities: Ability[];
-  visibility?: FamilyVisibility;
-  monsterCount?: number;
-  creatorId: string;
-  creator: User;
-}
-
 export interface Family extends FamilyOverview {
   monsters: Monster[];
 }
@@ -112,27 +116,6 @@ export interface Companion extends CompanionMini {
   paperforgeId?: string;
 }
 
-export interface Condition {
-  id: string;
-  name: string;
-  description: string;
-  official: boolean;
-}
-
-export interface Ability {
-  id: string;
-  name: string;
-  description: string;
-}
-
-export interface Action {
-  id: string;
-  name: string;
-  damage?: string;
-  range?: string;
-  description?: string;
-}
-
 export interface Collection extends CollectionOverview {
   monsters: Monster[];
   items: Item[];
@@ -160,23 +143,6 @@ export interface CollectionOverview {
   spellSchools: SpellSchoolMini[];
   visibility: CollectionVisibilityType;
   createdAt?: Date;
-}
-
-export const UNKNOWN_USER: User = {
-  id: "",
-  discordId: "",
-  username: "",
-  displayName: "",
-  imageUrl: "",
-};
-
-export interface User {
-  id: string;
-  discordId: string;
-  username: string;
-  displayName: string;
-  imageUrl?: string;
-  bannerDismissed?: boolean;
 }
 
 export const SUBCLASS_VISIBILITY = [
@@ -321,26 +287,3 @@ export type SpellSchoolSortOption =
   | "name-desc"
   | "created-asc"
   | "created-desc";
-
-export interface Source {
-  id: string;
-  name: string;
-  license: string;
-  link: string;
-  abbreviation: string;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-export interface Award {
-  id: string;
-  slug: string;
-  name: string;
-  abbreviation: string;
-  description?: string | null;
-  url: string;
-  color: string;
-  icon: string;
-  createdAt: Date;
-  updatedAt: Date;
-}

--- a/lib/types/base.ts
+++ b/lib/types/base.ts
@@ -1,0 +1,83 @@
+/**
+ * Base types that are used across the application.
+ * These types should NOT import from service modules to avoid circular dependencies.
+ */
+
+export interface User {
+  id: string;
+  discordId: string;
+  username: string;
+  displayName: string;
+  imageUrl?: string;
+  bannerDismissed?: boolean;
+}
+
+export const UNKNOWN_USER: User = {
+  id: "",
+  discordId: "",
+  username: "",
+  displayName: "",
+  imageUrl: "",
+};
+
+export interface Source {
+  id: string;
+  name: string;
+  license: string;
+  link: string;
+  abbreviation: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Award {
+  id: string;
+  slug: string;
+  name: string;
+  abbreviation: string;
+  description?: string | null;
+  url: string;
+  color: string;
+  icon: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Ability {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface Action {
+  id: string;
+  name: string;
+  damage?: string;
+  range?: string;
+  description?: string;
+}
+
+export interface Condition {
+  id: string;
+  name: string;
+  description: string;
+  official: boolean;
+}
+
+export const FAMILY_VISIBILITY = [
+  { value: "public", label: "Public" },
+  { value: "secret", label: "Secret" },
+  { value: "private", label: "Private" },
+] as const;
+export type FamilyVisibility = (typeof FAMILY_VISIBILITY)[number]["value"];
+
+export interface FamilyOverview {
+  id: string;
+  name: string;
+  description?: string;
+  abilities: Ability[];
+  visibility?: FamilyVisibility;
+  monsterCount?: number;
+  creatorId: string;
+  creator: User;
+}


### PR DESCRIPTION
## Summary
- Extract base types (User, Source, Award, Ability, Action, FamilyOverview, etc.) to `lib/types/base.ts`
- Create `lib/db/shared-converters.ts` for converter functions without circular deps
- Move `PaginateMonstersParams` and similar pagination types from service.ts to types.ts files
- Update imports to use `types.ts` directly instead of `index.ts` files
- Service converters now import from `shared-converters` instead of `lib/db/converters`

This reduces circular dependencies from 17 to 0.

## Test plan
- [x] Run `pnpm run test:circular` to verify no circular dependencies remain