### PR TITLE
Add example classes with loader UI for class builder

### DIFF
--- a/app/classes/BuildClassView.tsx
+++ b/app/classes/BuildClassView.tsx
@@ -22,11 +22,16 @@ import {
   useForm,
 } from "react-hook-form";
 import { z } from "zod";
+import {
+  EXAMPLE_CLASSES,
+  exampleClassToFormValues,
+} from "@/app/classes/exampleClasses";
 import { ClassDetailView } from "@/components/class/ClassDetailView";
 import { ConditionValidationIcon } from "@/components/condition/ConditionValidationIcon";
 import { DieFromNotation } from "@/components/icons/PolyhedralDice";
 import { DiscordLoginButton } from "@/components/layout/DiscordLoginButton";
 import { EditableLevelAbilities } from "@/components/shared/EditableLevelAbilities";
+import { ExampleLoader } from "@/components/shared/ExampleLoader";
 import { VisibilityToggle } from "@/components/shared/VisibilityToggle";
 import {
   AlertDialog,
@@ -286,6 +291,11 @@ export default function BuildClassView({ classEntity }: BuildClassViewProps) {
     classEntity?.subclassNamePreface,
   ]);
 
+  const loadExample = (exampleKey: string) => {
+    const example = EXAMPLE_CLASSES[exampleKey];
+    if (example) form.reset(exampleClassToFormValues(example));
+  };
+
   const handleSubmit = async (data: FormData) => {
     setIsSubmitting(true);
     try {
@@ -363,28 +373,37 @@ export default function BuildClassView({ classEntity }: BuildClassViewProps) {
               Preview
             </Toggle>
             {mode === "edit" && (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button type="button" variant="destructive">
-                    Clear
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent className="duration-0 [animation-duration:0s]">
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Clear form?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This will reset all fields. Any unsaved changes will be
-                      lost.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction onClick={() => form.reset()}>
+              <div className="flex items-center gap-2">
+                {!classEntity?.id && (
+                  <ExampleLoader
+                    examples={EXAMPLE_CLASSES}
+                    onLoadExample={loadExample}
+                    className="mb-0 mr-0"
+                  />
+                )}
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button type="button" variant="destructive">
                       Clear
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent className="duration-0 [animation-duration:0s]">
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Clear form?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This will reset all fields. Any unsaved changes will be
+                        lost.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction onClick={() => form.reset()}>
+                        Clear
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
             )}
           </div>
           {(draftState === "available" || draftState === "stale") && (

--- a/app/classes/exampleClasses.test.ts
+++ b/app/classes/exampleClasses.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { EXAMPLE_CLASSES, exampleClassToFormValues } from "./exampleClasses";
+
+describe("exampleClassToFormValues", () => {
+  const berserker = EXAMPLE_CLASSES.Berserker;
+
+  it("copies the example's top-level stats", () => {
+    const values = exampleClassToFormValues(berserker);
+    expect(values.name).toBe("Berserker");
+    expect(values.keyStats).toEqual(["STR", "DEX"]);
+    expect(values.hitDie).toBe("d12");
+    expect(values.startingHp).toBe(20);
+    expect(values.saves).toEqual({ STR: 1, DEX: 0, INT: -1, WIL: 0 });
+    expect(values.weapons).toEqual([{ type: "STR" }]);
+    expect(values.startingGear).toContain("Battleaxe");
+    expect(values.visibility).toBe("public");
+  });
+
+  it("expands to all 20 levels with the example's abilities", () => {
+    const values = exampleClassToFormValues(berserker);
+    expect(values.levels).toHaveLength(20);
+    expect(values.levels.map((l) => l.level)).toEqual(
+      Array.from({ length: 20 }, (_, i) => i + 1)
+    );
+    expect(values.levels[0].abilities.map((a) => a.name)).toEqual([
+      "Rage",
+      "That all you got?!",
+    ]);
+  });
+
+  it("keeps one blank ability row for levels the example does not define", () => {
+    const values = exampleClassToFormValues({
+      ...berserker,
+      levels: [{ level: 1, abilities: [{ name: "Rage", description: "..." }] }],
+    });
+    expect(values.levels[1].abilities).toHaveLength(1);
+    expect(values.levels[1].abilities[0]).toMatchObject({
+      name: "",
+      description: "",
+    });
+  });
+
+  it("assigns a unique id to every ability", () => {
+    const ids = exampleClassToFormValues(berserker).levels.flatMap((l) =>
+      l.abilities.map((a) => a.id)
+    );
+    expect(ids.every((id) => id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("carries over class option lists", () => {
+    const values = exampleClassToFormValues(berserker);
+    expect(values.abilityLists).toHaveLength(1);
+    expect(values.abilityLists[0].name).toBe("Savage Arsenal");
+    expect(values.abilityLists[0].items.length).toBeGreaterThan(0);
+  });
+});

--- a/app/classes/exampleClasses.ts
+++ b/app/classes/exampleClasses.ts
@@ -1,0 +1,398 @@
+import type {
+  ArmorType,
+  ClassAbility,
+  HitDieSize,
+  StatType,
+  WeaponSpec,
+} from "@/lib/types";
+import { randomUUID } from "@/lib/utils";
+
+const CLASS_LEVELS = 20;
+
+export interface ExampleClass {
+  name: string;
+  description: string;
+  keyStats: StatType[];
+  hitDie: HitDieSize;
+  startingHp: number;
+  saves: Record<StatType, number>;
+  armor: ArmorType[];
+  weapons: WeaponSpec[];
+  startingGear: string[];
+  levels: { level: number; abilities: Omit<ClassAbility, "id">[] }[];
+  abilityLists: {
+    name: string;
+    description: string;
+    items: { name: string; description: string }[];
+  }[];
+}
+
+/**
+ * Expands an example into builder form values: every level 1-20 is present,
+ * abilities get fresh ids, and empty levels keep one blank ability row.
+ */
+export function exampleClassToFormValues(example: ExampleClass) {
+  return {
+    name: example.name,
+    description: example.description,
+    keyStats: example.keyStats,
+    hitDie: example.hitDie,
+    startingHp: example.startingHp,
+    saves: example.saves,
+    armor: example.armor,
+    weapons: example.weapons,
+    startingGear: example.startingGear,
+    levels: Array.from({ length: CLASS_LEVELS }, (_, i) => {
+      const abilities = example.levels.find(
+        (l) => l.level === i + 1
+      )?.abilities;
+      return {
+        level: i + 1,
+        abilities: abilities?.length
+          ? abilities.map((a) => ({ ...a, id: randomUUID() }))
+          : [{ id: randomUUID(), name: "", description: "" }],
+      };
+    }),
+    abilityLists: example.abilityLists.map((l) => ({
+      name: l.name,
+      description: l.description,
+      items: l.items.map((item) => ({
+        name: item.name,
+        description: item.description,
+      })),
+    })),
+    visibility: "public" as const,
+  };
+}
+
+export const EXAMPLE_CLASSES: Record<string, ExampleClass> = {
+  Berserker: {
+    name: "Berserker",
+    description:
+      "Wrath and Ruin. The Berserker is destruction. He knows not fatigue nor caution—both surely driven away from him in a relentless fury. Those of barbaric nature are said to eat only the dust of war and drink naught but the blood of those felled by their own hand.\n\nDeath is no stranger, for it is said that even death fears to take a Berserker before his battle Rage is satiated. Once a Berserker has begun to fight, he only grows stronger, fueled by battle-lust and an unending Rage. The deadliest among them is not the well-rested, but those who are pushed to the brink through combat.",
+    keyStats: ["STR", "DEX"],
+    hitDie: "d12",
+    startingHp: 20,
+    saves: {
+      STR: 1,
+      DEX: 0,
+      INT: -1,
+      WIL: 0,
+    },
+    armor: [],
+    weapons: [
+      {
+        type: "STR",
+      },
+    ],
+    startingGear: ["Battleaxe", "Rations (meat)", "Rope (50 ft.)"],
+    levels: [
+      {
+        level: 1,
+        abilities: [
+          {
+            name: "Rage",
+            description:
+              "(1/turn) Action: Roll a Fury Die (1d4) and set it aside. Add it to every STR attack you make. You can have a max of KEY Fury Dice; they are lost when your Rage ends.",
+          },
+          {
+            name: "That all you got?!",
+            description:
+              "When you are attacked, you may expend 1 or more Fury Dice to reduce the damage taken by STR+DEX for each die spent.",
+          },
+        ],
+      },
+      {
+        level: 2,
+        abilities: [
+          {
+            name: "Intensifying Fury",
+            description:
+              "If you are Raging at the beginning of your turn, roll 1 Fury Die for free.",
+          },
+          {
+            name: "One with the Ancients",
+            description:
+              "(1/Safe Rest) When faced with a decision about which direction or course of action to take, you can call upon your ancestors to guide you toward the most dangerous or challenging path.",
+          },
+        ],
+      },
+      {
+        level: 3,
+        abilities: [
+          {
+            name: "Subclass",
+            description: "Choose a Berserker subclass.",
+          },
+          {
+            name: "Bloodlust",
+            description:
+              "Expend 1 or more Fury Dice on your turn, move DEX spaces per die spent for free.",
+          },
+        ],
+      },
+      {
+        level: 4,
+        abilities: [
+          {
+            name: "Enduring Rage",
+            description:
+              "While Dying, you Rage automatically for free at the beginning of your turn, have a max of 2 actions instead of 1, and ignore the STR saves to make attacks.",
+          },
+          {
+            name: "Key Stat Increase",
+            description: "+1 STR or DEX.",
+          },
+          {
+            name: "Savage Arsenal",
+            description: "Choose 1 ability from the Savage Arsenal.",
+          },
+        ],
+      },
+      {
+        level: 5,
+        abilities: [
+          {
+            name: "Rage (2)",
+            description: "Whenever you Rage, gain 2 Fury Dice instead.",
+          },
+          {
+            name: "Secondary Stat Increase",
+            description: "+1 INT or WIL.",
+          },
+        ],
+      },
+      {
+        level: 6,
+        abilities: [
+          {
+            name: "Savage Arsenal (2)",
+            description: "Choose a 2nd Savage Arsenal ability.",
+          },
+          {
+            name: "Intensifying Fury (2)",
+            description: "Your Fury Dice are now d6s.",
+          },
+        ],
+      },
+      {
+        level: 7,
+        abilities: [
+          {
+            name: "Subclass",
+            description: "Gain your Berserker subclass feature.",
+          },
+        ],
+      },
+      {
+        level: 8,
+        abilities: [
+          {
+            name: "Savage Arsenal (3)",
+            description: "Choose a 3rd Savage Arsenal ability.",
+          },
+          {
+            name: "Key Stat Increase",
+            description: "+1 STR or DEX.",
+          },
+        ],
+      },
+      {
+        level: 9,
+        abilities: [
+          {
+            name: "Intensifying Fury (3)",
+            description: "Your Fury Dice are now d8s.",
+          },
+          {
+            name: "Secondary Stat Increase",
+            description: "+1 INT or WIL.",
+          },
+        ],
+      },
+      {
+        level: 10,
+        abilities: [
+          {
+            name: "Savage Arsenal (4)",
+            description: "Choose a 4th Savage Arsenal ability.",
+          },
+        ],
+      },
+      {
+        level: 11,
+        abilities: [
+          {
+            name: "Subclass",
+            description: "Gain your Berserker subclass feature.",
+          },
+        ],
+      },
+      {
+        level: 12,
+        abilities: [
+          {
+            name: "Savage Arsenal (5)",
+            description: "Choose a 5th Savage Arsenal ability.",
+          },
+          {
+            name: "Key Stat Increase",
+            description: "+1 STR or DEX.",
+          },
+        ],
+      },
+      {
+        level: 13,
+        abilities: [
+          {
+            name: "Intensifying Fury (4)",
+            description: "Your Fury Dice are now d10s.",
+          },
+          {
+            name: "Secondary Stat Increase",
+            description: "+1 INT or WIL.",
+          },
+        ],
+      },
+      {
+        level: 14,
+        abilities: [
+          {
+            name: "Savage Arsenal (6)",
+            description: "Choose a 6th Savage Arsenal ability.",
+          },
+        ],
+      },
+      {
+        level: 15,
+        abilities: [
+          {
+            name: "Subclass",
+            description: "Gain your Berserker subclass feature.",
+          },
+        ],
+      },
+      {
+        level: 16,
+        abilities: [
+          {
+            name: "Savage Arsenal (7)",
+            description: "Choose a 7th Savage Arsenal ability.",
+          },
+          {
+            name: "Key Stat Increase",
+            description: "+1 STR or DEX.",
+          },
+        ],
+      },
+      {
+        level: 17,
+        abilities: [
+          {
+            name: "Intensifying Fury (5)",
+            description: "Your Fury Dice are now d12s.",
+          },
+          {
+            name: "Secondary Stat Increase",
+            description: "+1 INT or WIL.",
+          },
+        ],
+      },
+      {
+        level: 18,
+        abilities: [
+          {
+            name: "DEEP RAGE",
+            description: "Dropping to 0 HP does not cause your Rage to end.",
+          },
+        ],
+      },
+      {
+        level: 19,
+        abilities: [
+          {
+            name: "Epic Boon",
+            description: "Choose an Epic Boon.",
+          },
+        ],
+      },
+      {
+        level: 20,
+        abilities: [
+          {
+            name: "BOUNDLESS RAGE",
+            description:
+              "+1 to any 2 of your stats. Anytime you roll less than 6 on a Fury Die, change it to 6 instead.",
+          },
+        ],
+      },
+    ],
+    abilityLists: [
+      {
+        name: "Savage Arsenal",
+        description: "Choose Savage Arsenal abilities as you level up.",
+        items: [
+          {
+            name: "Death Blow",
+            description:
+              "After you deal damage from a crit, you may expend any number of Fury Dice. Sum the dice and deal double that amount of damage.",
+          },
+          {
+            name: "Deathless Rage",
+            description:
+              "(1/turn) While Dying, you may suffer 1 Wound to gain 1 action.",
+          },
+          {
+            name: "Eager for Battle",
+            description:
+              "Gain advantage on Initiative. Move 2×DEX spaces for free on your first turn each encounter.",
+          },
+          {
+            name: "Into the Fray",
+            description:
+              "Action: Leap up to 2×DEX spaces toward an enemy. If you land adjacent to at least 2 enemies, make an attack against 1 of them for free.",
+          },
+          {
+            name: "Mighty Endurance",
+            description:
+              "You can now survive an additional 4 Wounds before death.",
+          },
+          {
+            name: "MORE BLOOD!",
+            description: "Whenever an enemy crits you, gain 1 Fury Die.",
+          },
+          {
+            name: "Rampage",
+            description:
+              "(1/turn) After you land a hit, you may treat your next attack this turn as if you rolled that same amount instead of rolling again.",
+          },
+          {
+            name: "Swift Fury",
+            description:
+              "Whenever you gain one or more Fury Dice, move up to DEX spaces for free, ignoring difficult terrain.",
+          },
+          {
+            name: "Thunderous Steps",
+            description:
+              "After moving at least 4 spaces while Raging, you may deal STR Bludgeoning damage to all adjacent creatures where you stop.",
+          },
+          {
+            name: "Unstoppable Force",
+            description:
+              "While Dying and Raging, taking damage causes 1 Wound (instead of 2) and critical hits inflict 2 Wounds (instead of 3).",
+          },
+          {
+            name: "Whirlwind",
+            description:
+              "2 actions: Attack ALL targets within your melee weapon's reach.",
+          },
+          {
+            name: "You're Next!",
+            description:
+              "Action: While Raging, you can make a Might skill check to demoralize an enemy within Reach 12 (DC: their current HP). On a success, they immediately flee the battle.",
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/components/shared/ExampleLoader.tsx
+++ b/components/shared/ExampleLoader.tsx
@@ -2,20 +2,23 @@
 
 import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface ExampleLoaderProps<T> {
   examples: Record<string, T>;
   onLoadExample: (type: string) => void;
   getIcon?: (example: T) => LucideIcon | undefined;
+  className?: string;
 }
 
 export function ExampleLoader<T>({
   examples,
   onLoadExample,
   getIcon,
+  className,
 }: ExampleLoaderProps<T>) {
   return (
-    <div className="flex mb-6 mr-5 justify-end">
+    <div className={cn("flex mb-6 mr-5 justify-end", className)}>
       <div className="flex items-center">
         <span className="text-sm font-bold mr-2">Load:</span>
         {Object.keys(examples).map((type) => {
@@ -23,6 +26,7 @@ export function ExampleLoader<T>({
           return (
             <Button
               key={type}
+              type="button"
               variant="ghost"
               className="small-caps text-sm"
               onClick={() => onLoadExample(type)}


### PR DESCRIPTION
## Summary
Adds a system for defining and loading example classes in the class builder, starting with the Berserker class. Users can now load pre-built class templates when creating new classes.

## Key Changes
- **New `exampleClasses.ts` module**: Defines `ExampleClass` interface and `EXAMPLE_CLASSES` registry with the Berserker class (full 20-level progression with abilities and Savage Arsenal options)
- **`exampleClassToFormValues()` function**: Converts example classes to form-ready values, expanding to all 20 levels, assigning unique IDs to abilities, and ensuring empty levels have a blank ability row
- **Updated `BuildClassView`**: Integrates `ExampleLoader` component for new classes (hidden when editing existing classes), with a `loadExample()` handler that resets the form with selected example data
- **Enhanced `ExampleLoader` component**: Added optional `className` prop for flexible styling
- **Comprehensive test coverage**: Added `exampleClasses.test.ts` with tests for form value conversion, level expansion, ability ID generation, and ability list handling

## Implementation Details
- Example classes are only loadable when creating new classes (`!classEntity?.id`), preventing accidental overwrites of existing work
- The Berserker example includes detailed progression with stat increases, subclass features, and 12 Savage Arsenal abilities to choose from
- All abilities receive fresh UUIDs during conversion to prevent ID collisions in the form

https://claude.ai/code/session_01AH6rM1CVa3rU24NkjGujTB